### PR TITLE
Spaced names cities bug fix

### DIFF
--- a/weatherplugin.cpp
+++ b/weatherplugin.cpp
@@ -1,4 +1,4 @@
-﻿#include "weatherplugin.h"
+#include "weatherplugin.h"
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QMessageBox>
@@ -226,7 +226,7 @@ void WeatherPlugin::set()
     hbox->addWidget(label);
     QLineEdit *lineEdit_city = new QLineEdit;
     lineEdit_city->setPlaceholderText("English Only");
-    QRegExp regExp("[a-zA-Z]+$");
+    QRegExp regExp("[A-Za-z ]+$");
     QValidator *validator = new QRegExpValidator(regExp, lineEdit_city);
     lineEdit_city->setValidator(validator);
     lineEdit_city->setText(m_settings.value("city","").toString());


### PR DESCRIPTION
The `QLineEdit` from the `set` dialog does not able us to type cities with space in the name
(e.g: Rio de Janeiro, São Paulo, New York, Los Angeles, etc). I've modified the regular expression to allow us to uses space in the city name.

For the ones reading it before the fix, you can modify the city name manually in the file $HOME/.config/deepin/dde-dock-HTYWeather.conf
